### PR TITLE
Minor improvements from user feedback

### DIFF
--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0.8"
+  s.version      = "7.0.9"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0.7"
+  s.version      = "7.0.8"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0.6"
+  s.version      = "7.0.7"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
+++ b/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
@@ -75,6 +75,7 @@
     betweenElementsSpace =  (availableBufferSpace * 0.2) / (numLabels + numButtonPairs + numTextInputs);
     
     int currentY = topLeadingSpace;
+    int inputFieldTag = 0;
     
     // second pass - render objects
     modalComponentElement = fallbackElement->firstChild;
@@ -110,6 +111,9 @@
                                                                                 presentingView:presentingView];
             
             currentY = inputFieldView.frame.origin.y + inputFieldView.frame.size.height + betweenElementsSpace;
+            
+            // i love C sleight of hand :)
+            inputFieldView.inputTextField.tag = inputFieldTag++;
             
             [self.inputFieldViews addObject:inputFieldView];
             [self addSubview:inputFieldView];

--- a/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
+++ b/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
@@ -75,7 +75,7 @@
     betweenElementsSpace =  (availableBufferSpace * 0.2) / (numLabels + numButtonPairs + numTextInputs);
     
     int currentY = topLeadingSpace;
-    int inputFieldTag = 0;
+    int inputFieldTag = BASE_TAG_INPUTFIELDTEXT;
     
     // second pass - render objects
     modalComponentElement = fallbackElement->firstChild;

--- a/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
+++ b/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
@@ -70,14 +70,9 @@
         modalComponentElement = modalComponentElement->nextSibling;
     }
     
-    // there are too many elements, not sure what to do
-    if (totalUsedSpace >= totalVerticalSpace) {
-        
-    } else {
-        CGFloat availableBufferSpace = totalVerticalSpace - totalUsedSpace;
-        topLeadingSpace =       availableBufferSpace * 0.15;
-        betweenElementsSpace =  (availableBufferSpace * 0.2) / (numLabels + numButtonPairs + numTextInputs);
-    }
+    CGFloat availableBufferSpace = totalVerticalSpace - totalUsedSpace;
+    topLeadingSpace =       availableBufferSpace * 0.15;
+    betweenElementsSpace =  (availableBufferSpace * 0.2) / (numLabels + numButtonPairs + numTextInputs);
     
     int currentY = topLeadingSpace;
     

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.h
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.h
@@ -11,7 +11,9 @@
 
 @class GTPageStyle;
 
-@interface GTInputFieldView : UIView<UITextFieldDelegate>
+@interface GTInputFieldView : UIView
+
+@property (strong, nonatomic) UITextField           *inputTextField;
 
 - (instancetype)inputFieldWithElement:(TBXMLElement *)element withY:(CGFloat)yPos withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView;
 

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -17,7 +17,6 @@
 @interface GTInputFieldView ()
 
 @property (strong, nonatomic) NSString              *inputFieldType;
-@property (strong, nonatomic) UITextField           *inputTextField;
 @end
 
 @implementation GTInputFieldView
@@ -96,8 +95,7 @@
     [self.inputTextField setFrame:CGRectMake(0, inputFieldLabel.frame.size.height, w, h)];
     [self.inputTextField setTextColor:[UIColor darkTextColor]];
     [self.inputTextField setBackgroundColor:[UIColor whiteColor]];
-    [self.inputTextField setReturnKeyType:UIReturnKeyDone];
-    self.inputTextField.delegate = self;
+    [self.inputTextField setReturnKeyType:UIReturnKeyNext];
     
     [inputFieldView setFrame:CGRectMake(x, y, w, self.inputTextField.frame.size.height + inputFieldLabel.frame.size.height)];
     
@@ -111,12 +109,5 @@
 - (NSString *)inputFieldValue {
     return self.inputTextField.text;
 }
-
-
-- (BOOL)textFieldShouldReturn:(UITextField *)textField {
-    [textField resignFirstResponder];
-    return NO;
-}
-
 
 @end

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
@@ -16,7 +16,7 @@ extern NSString *const GTFollowupViewControllerFieldKeyFollowupId;
 
 @class GTFollowupModalView, GTFollowupThankYouView;
 
-@interface GTFollowupViewController : UIViewController
+@interface GTFollowupViewController : UIViewController<UITextFieldDelegate>
 
 @property (strong,nonatomic) GTFollowupModalView *followupModalView;
 @property (strong,nonatomic) GTFollowupThankYouView *followupThankYouView;

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -22,7 +22,6 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 @interface GTFollowupViewController ()
 
-@property (strong, nonatomic)       NSNumber *keyboardIsShowing;
 @property (weak, nonatomic)         UITextField *activeField;
 @property (assign, nonatomic)       CGFloat originalHeight;
 
@@ -74,9 +73,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 - (void) viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
-    self.keyboardIsShowing = @NO;
-    
+        
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(sendFollowupSubscribeListener:)
                                                  name:UISnuffleButtonNotificationButtonTapEvent
@@ -154,16 +151,14 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 #pragma mark Animation methods to prevent text field from being hidden
 // logic adapted from from: http://stackoverflow.com/questions/1126726/how-to-make-a-uitextfield-move-up-when-keyboard-is-present
 -(void)keyboardWillShow:(NSNotification *) notification {
-    if ([self.keyboardIsShowing boolValue] || self.view.frame.origin.y < 0) {
+    if (self.view.frame.origin.y < 0) {
         return;
     }
     
     [self moveView:notification];
-    self.keyboardIsShowing = @YES;
 }
 
 -(void)keyboardWillHide:(NSNotification *) notification {
-    self.keyboardIsShowing = @NO;
     
     if (self.view.frame.origin.y >= 0) {
         return;

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -278,6 +278,9 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 - (void)textFieldDidBeginEditing:(UITextField *)textField {
     self.activeField = textField;
+    if (![textField.superview.superview viewWithTag:textField.tag + 1]) {
+        [textField setReturnKeyType:UIReturnKeyDone];
+    }
 }
 
 

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -149,7 +149,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 
 #pragma mark Animation methods to prevent text field from being hidden
-// logic adapted from from: http://stackoverflow.com/questions/1126726/how-to-make-a-uitextfield-move-up-when-keyboard-is-present
+
 -(void)keyboardWillShow:(NSNotification *) notification {
     if (self.view.frame.origin.y < 0) {
         return;
@@ -168,7 +168,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 }
 
 
-//method to move the view up/down whenever the keyboard is shown/dismissed
+//method to move the view up when the keyboard would cover the "active" textField
 -(void)moveView:(NSNotification *)notification {
     NSDictionary *userInfo = notification.userInfo;
     
@@ -192,6 +192,11 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
     CGFloat viewVerticalDelta = (inputFieldViewFrame.origin.y + inputFieldViewFrame.size.height) - unobscuredByKeyboardFrame.size.height;
     
+    [self animateViewWithVerticalDelta:viewVerticalDelta userInfo:userInfo];
+}
+
+
+- (void) animateViewWithVerticalDelta:(CGFloat)verticalDelta userInfo:(NSDictionary *)userInfo {
     // Get animation info from userInfo
     NSTimeInterval animationDuration;
     UIViewAnimationCurve animationCurve;
@@ -204,8 +209,8 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     [UIView setAnimationDuration:animationDuration];
     [UIView setAnimationCurve:animationCurve];
     
-    newViewFrame.origin.y -= viewVerticalDelta;
-    newViewFrame.size.height += viewVerticalDelta;
+    newViewFrame.origin.y -= verticalDelta;
+    newViewFrame.size.height += verticalDelta;
     self.view.frame = newViewFrame;
     
     [UIView commitAnimations];
@@ -234,6 +239,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     [UIView commitAnimations];
 }
 
+#pragma mark - UITextFieldDelegate methods
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField {
     [textField resignFirstResponder];

--- a/GTViewController/Classes/Nav Classes/GTViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTViewController.m
@@ -350,7 +350,7 @@ NSString * const kAttr_listeners	= @"listeners";
             self.bypassPresentingNavbar = YES;
             __weak typeof(self) weakSelf = self;
             
-            [self dismissViewControllerAnimated:YES completion:^{
+            [self.followupViewController dismissViewControllerAnimated:YES completion:^{
                 weakSelf.bypassPresentingNavbar = NO;
             }];
         }
@@ -1022,10 +1022,8 @@ NSString * const kAttr_listeners	= @"listeners";
         
     }
     
-    self.navToolbarIsShown		= NO;
-    
     CGRect toolbarFrame			= self.navToolbar.frame;
-    toolbarFrame.origin.y		= self.view.frame.size.height - TOOLBAR_PEEK;
+    toolbarFrame.origin.y		= CGRectGetHeight(self.view.frame) - TOOLBAR_PEEK;
     CGRect toolbarButtonFrame	= self.navToolbarButton.frame;
     toolbarButtonFrame.origin.y	= toolbarFrame.origin.y - self.navToolbarButton.frame.size.height;
     
@@ -1044,8 +1042,7 @@ NSString * const kAttr_listeners	= @"listeners";
 
 - (void)hideNavToolbarDidStop {
     
-    
-    
+    self.navToolbarIsShown = NO;
 }
 
 #pragma mark - GTPageDelegate

--- a/GTViewController/Classes/Nav Classes/GTViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTViewController.m
@@ -163,6 +163,8 @@ NSString * const kAttr_listeners	= @"listeners";
 @property (nonatomic, assign)	BOOL						isFirstRunSinceCreation;
 @property (nonatomic, strong)	NSArray						*allURLsButtonArray;
 
+@property (nonatomic, assign)   BOOL                        bypassPresentingNavbar;
+
 //config functions
 - (NSMutableArray *)pageArrayForConfigFile:(NSString *)filename;
 
@@ -345,9 +347,11 @@ NSString * const kAttr_listeners	= @"listeners";
         
         // dismiss a follow up modal if it is present and displayed
         if (self.followupViewController) {
+            self.bypassPresentingNavbar = YES;
             __weak typeof(self) weakSelf = self;
+            
             [self dismissViewControllerAnimated:YES completion:^{
-                [weakSelf hideNavToolbar];
+                weakSelf.bypassPresentingNavbar = NO;
             }];
         }
     }
@@ -1180,9 +1184,11 @@ NSString * const kAttr_listeners	= @"listeners";
 }
 
 - (void)dismissFollowupModal {
+    self.bypassPresentingNavbar = YES;
     __weak typeof(self) weakSelf = self;
+    
     [self.followupViewController dismissViewControllerAnimated:YES completion:^{
-        [weakSelf hideNavToolbar];
+        weakSelf.bypassPresentingNavbar = NO;
     }];
     
 }
@@ -2001,8 +2007,6 @@ NSString * const kAttr_listeners	= @"listeners";
     
     [super viewWillAppear:animated];
     
-    //[self setUpViewController];
-    
     //calculate the positions the views will have during animation
     self.inViewInCenterCenter = CGPointMake(self.view.frame.size.width / 2, self.view.center.y);
     self.outOfViewOnRightCenter = CGPointMake((3 * self.inViewInCenterCenter.x) + self.gapBetweenViews, self.inViewInCenterCenter.y);
@@ -2019,7 +2023,10 @@ NSString * const kAttr_listeners	= @"listeners";
     
     [self navToolbarAddRemoveSwitchButton];
     [self navToolbarAddRemoveRefreshButton];
-    [self showNavToolbar];
+    
+    if (!self.bypassPresentingNavbar) {
+        [self showNavToolbar];
+    }
     
 }
 

--- a/GTViewController/Classes/Nav Classes/GTViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTViewController.m
@@ -345,7 +345,10 @@ NSString * const kAttr_listeners	= @"listeners";
         
         // dismiss a follow up modal if it is present and displayed
         if (self.followupViewController) {
-            [self dismissViewControllerAnimated:YES completion:nil];
+            __weak typeof(self) weakSelf = self;
+            [self dismissViewControllerAnimated:YES completion:^{
+                [weakSelf hideNavToolbar];
+            }];
         }
     }
 }
@@ -1015,6 +1018,8 @@ NSString * const kAttr_listeners	= @"listeners";
         
     }
     
+    self.navToolbarIsShown		= NO;
+    
     CGRect toolbarFrame			= self.navToolbar.frame;
     toolbarFrame.origin.y		= self.view.frame.size.height - TOOLBAR_PEEK;
     CGRect toolbarButtonFrame	= self.navToolbarButton.frame;
@@ -1035,7 +1040,7 @@ NSString * const kAttr_listeners	= @"listeners";
 
 - (void)hideNavToolbarDidStop {
     
-    self.navToolbarIsShown		= NO;
+    
     
 }
 
@@ -1175,7 +1180,11 @@ NSString * const kAttr_listeners	= @"listeners";
 }
 
 - (void)dismissFollowupModal {
-    [self.followupViewController dismissViewControllerAnimated:YES completion:nil];
+    __weak typeof(self) weakSelf = self;
+    [self.followupViewController dismissViewControllerAnimated:YES completion:^{
+        [weakSelf hideNavToolbar];
+    }];
+    
 }
 
 #pragma mark - User Interaction methods
@@ -1448,9 +1457,7 @@ NSString * const kAttr_listeners	= @"listeners";
     
     if (touch.tapCount == 20) {
         [self fiftyTap];
-    }
-    
-    if (touch.tapCount == 1) {
+    } else if (touch.tapCount > 1) {
         [self.centerPage tapAnywhere];
         
         if (self.navToolbarIsShown) {

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
@@ -49,6 +49,9 @@
 #define DEFAULT_HEIGHT_BIGBUTTON 136.0
 #define DEFAULT_HEIGHT_ALLURLBUTTON 36.0
 #define DEFAULT_HEIGHT_LINKBUTTON 40.0
+
+#define BASE_TAG_INPUTFIELDTEXT 3580
+
 //////////Run-Time Constants///////////
 
 // Constants for the XML element names that will be considered during the parse.


### PR DESCRIPTION
For follow up modal views
- Followup views will now adjust their height and y position to ensure that the keyboard doesn't hide the data input field that's being interacted with
- The next button will hop from one input field to the next.  It will change to 'Done' when on the last field
- The nav bar will not be shown when the follow up view modal dismisses

For the entire renderer:
- a single tap anywhere on the screen (besides an element of any kind) will hide the navbar if it's shown
- a double tap anywhere on the screen (besides an element of any kind will show the navbar.
- this fixes an annoyance that exists in production where the navbar will hide and immediately reshow itself on a single tap
- twenty taps exhibits some random behavior.  further investigation required..