### PR TITLE
Add input validation on follow up modal

### DIFF
--- a/Example/GTViewController/Packages/07_SuggestedPrayer.xml
+++ b/Example/GTViewController/Packages/07_SuggestedPrayer.xml
@@ -49,7 +49,7 @@ Thank You for forgiving my sins and giving me eternal life.  Take control of the
                 <input-placeholder>John Doe (Optional)</input-placeholder>
             </input-field>
             <button-pair align="right" xoffset="30" x-trailing-offset="30">
-                <positive-button h="40" w="80" force-validation="true" tap-events="follow-up-send,followup:subscribe">Send</positive-button>
+                <positive-button h="40" w="80" tap-events="follow-up-send,followup:subscribe">Send</positive-button>
                 <negative-button h="40" w="120" size="70" mode="link" tap-events="follow-up-no-thanks">No Thanks</negative-button>
             </button-pair>
             

--- a/Example/GTViewController/Packages/07_SuggestedPrayer.xml
+++ b/Example/GTViewController/Packages/07_SuggestedPrayer.xml
@@ -40,7 +40,7 @@ Thank You for forgiving my sins and giving me eternal life.  Take control of the
         <fallback>
             <followup-title modifier="bold" x="0" xoffset="30" x-trailing-offset="30">Jesus has come into your life as he promised.</followup-title>
             <followup-body modifier="bold" yoffset="40" x="0" xoffset="30" x-trailing-offset="30">Knowing someone better helps a relationship grow. Would you like to sign up for an email series that can help guide you in your new relationship with Jesus Christ?</followup-body>
-            <input-field name="email" type="email" xoffset="30" yoffset="10" x-trailing-offset="30" valid-format="[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}">
+            <input-field name="email" type="email" xoffset="30" yoffset="10" x-trailing-offset="30">
                 <input-label modifier="bold" size="80">Email</input-label>
                 <input-placeholder>john.doe@gmail.com</input-placeholder>
             </input-field>
@@ -49,12 +49,12 @@ Thank You for forgiving my sins and giving me eternal life.  Take control of the
                 <input-placeholder>John Doe (Optional)</input-placeholder>
             </input-field>
             <button-pair align="right" xoffset="30" x-trailing-offset="30">
-                <positive-button h="40" w="80" tap-events="followup:subscribe">Send</positive-button>
+                <positive-button h="40" w="80" force-validation="true" tap-events="follow-up-send,followup:subscribe">Send</positive-button>
                 <negative-button h="40" w="120" size="70" mode="link" tap-events="follow-up-no-thanks">No Thanks</negative-button>
             </button-pair>
             
             <!-- thank-you should be handled as an embedded page -->
-            <thank-you listeners="followup:subscribe">
+            <thank-you listeners="follow-up-send">
                 <text modifier="bold" textalign="center" size="100" xoffset="30" x-trailing-offset="30">Thank you</text>
                 <text textalign="left" size="100" xoffset="30" x-trailing-offset="30">Check your email soon for your first study in following Jesus Christ.</text>
                 <text textalign="left" size="100" xoffset="30" x-trailing-offset="30">If you don't receive it, please check your spam folder.</text>

--- a/Example/GTViewController/Packages/07_SuggestedPrayer.xml
+++ b/Example/GTViewController/Packages/07_SuggestedPrayer.xml
@@ -40,21 +40,21 @@ Thank You for forgiving my sins and giving me eternal life.  Take control of the
         <fallback>
             <followup-title modifier="bold" x="0" xoffset="30" x-trailing-offset="30">Jesus has come into your life as he promised.</followup-title>
             <followup-body modifier="bold" yoffset="40" x="0" xoffset="30" x-trailing-offset="30">Knowing someone better helps a relationship grow. Would you like to sign up for an email series that can help guide you in your new relationship with Jesus Christ?</followup-body>
-            <input-field name="email" type="email" xoffset="30" yoffset="10" x-trailing-offset="30">
+            <input-field name="email" type="email" xoffset="30" yoffset="10" x-trailing-offset="30" valid-format="[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}">
                 <input-label modifier="bold" size="80">Email</input-label>
                 <input-placeholder>john.doe@gmail.com</input-placeholder>
             </input-field>
-            <input-field name="name" type="text" xoffset="30" yoffset="10" x-trailing-offset="30">
+            <input-field name="name" type="text" xoffset="30" yoffset="10" x-trailing-offset="30" valid-format="[A-Za-z]+">
                 <input-label modifier="bold" size="80">Name</input-label>
                 <input-placeholder>John Doe (Optional)</input-placeholder>
             </input-field>
             <button-pair align="right" xoffset="30" x-trailing-offset="30">
-                <positive-button h="40" w="80" tap-events="follow-up-send,followup:subscribe">Send</positive-button>
+                <positive-button h="40" w="80" tap-events="followup:subscribe">Send</positive-button>
                 <negative-button h="40" w="120" size="70" mode="link" tap-events="follow-up-no-thanks">No Thanks</negative-button>
             </button-pair>
             
             <!-- thank-you should be handled as an embedded page -->
-            <thank-you listeners="follow-up-send">
+            <thank-you listeners="followup:subscribe">
                 <text modifier="bold" textalign="center" size="100" xoffset="30" x-trailing-offset="30">Thank you</text>
                 <text textalign="left" size="100" xoffset="30" x-trailing-offset="30">Check your email soon for your first study in following Jesus Christ.</text>
                 <text textalign="left" size="100" xoffset="30" x-trailing-offset="30">If you don't receive it, please check your spam folder.</text>

--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0-rc.1"
+  s.version      = "7.0.11"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "6.0"
   s.source       = { :git => "https://github.com/CruGlobal/GTViewController.git", :tag => s.version }
   s.source_files = "GTViewController/Classes/**/*.{h,m}", "GTViewController/Headers/*.h"
-  s.public_header_files = "GTViewController/Classes/Nav\ Classes/GTViewController.h", "GTViewController/Classes/Custom\ Classes/GTFileLoader.h", "GTViewController/Classes/Nav\ Classes/GTPageMenuViewController.h", "GTViewController/Classes/Custom\ Classes/GTShareViewController.h", "GTViewController/Classes/Custom\ Classes/GTShareInfo.h", "GTViewController/Classes/Parsing\ Classes/GTAboutViewController.h", "GTViewController/Classes/TBXML/TBXML.h", "GTViewController/Classes/Nav\ Classes/GTFollowupViewController.h"
+  s.public_header_files = "GTViewController/Classes/Nav\ Classes/GTViewController.h", "GTViewController/Classes/Custom\ Classes/GTFileLoader.h", "GTViewController/Classes/Nav\ Classes/GTPageMenuViewController.h", "GTViewController/Classes/Custom\ Classes/GTShareViewController.h", "GTViewController/Classes/Custom\ Classes/GTShareInfo.h", "GTViewController/Classes/Parsing\ Classes/GTAboutViewController.h", "GTViewController/Classes/TBXML/TBXML.h", "GTViewController/Classes/Nav\ Classes/GTFollowupViewController.h", "GTViewController/Classes/Custom\ Classes/UISnuffleButton.h"
   s.resources    = "GTViewController/Resources/*", "GTViewController/Classes/**/*.xib"
   s.frameworks   = "QuartzCore", "AVFoundation"
   s.libraries    = "z"

--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0.9"
+  s.version      = "7.0-rc.1"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController/Classes/Custom Classes/GTFollowupModalView.h
+++ b/GTViewController/Classes/Custom Classes/GTFollowupModalView.h
@@ -21,7 +21,7 @@
 @property (strong, nonatomic) NSMutableArray *inputFieldViews;
 @property (strong, nonatomic) NSString *followupId;
 
-- (instancetype)initFromElement:(TBXMLElement *)element withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView interpreterDelegate:(id<GTInterpreterDelegate>)interpreterDelegate;
+- (instancetype)initFromElement:(TBXMLElement *)element withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView interpreterDelegate:(id<GTInterpreterDelegate>)interpreterDelegate buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate;
 
 - (void)setWatermark:(UIImageView *) watermarkImageView;
 @end

--- a/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
+++ b/GTViewController/Classes/Custom Classes/GTFollowupModalView.m
@@ -22,7 +22,7 @@
 
 @implementation GTFollowupModalView
 
-- (instancetype)initFromElement:(TBXMLElement *)element withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView interpreterDelegate:(id<GTInterpreterDelegate>)interpreterDelegate {
+- (instancetype)initFromElement:(TBXMLElement *)element withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView interpreterDelegate:(id<GTInterpreterDelegate>)interpreterDelegate buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate {
     
     self = [super initWithFrame:presentingView.frame];
 
@@ -126,7 +126,8 @@
                                                                                                   parentElement:modalComponentElement
                                                                                                       yPosition:currentY
                                                                                                   containerView:self
-                                                                                                      withStyle:style];
+                                                                                                      withStyle:style
+                                                                                              buttonTapDelegate:tapDelegate];
             
             [self addSubview:buttonPairView];
             

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.h
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.h
@@ -19,5 +19,7 @@
 
 - (NSString *)inputFieldType;
 - (NSString *)inputFieldValue;
+- (BOOL) isValid;
+- (NSString *)validationMessage;
 
 @end

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.h
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.h
@@ -14,10 +14,10 @@
 @interface GTInputFieldView : UIView
 
 @property (strong, nonatomic) UITextField           *inputTextField;
+@property (strong, nonatomic, readonly) NSString    *parameterName;
 
 - (instancetype)inputFieldWithElement:(TBXMLElement *)element withY:(CGFloat)yPos withStyle:(GTPageStyle*)style presentingView:(UIView *)presentingView;
 
-- (NSString *)inputFieldType;
 - (NSString *)inputFieldValue;
 - (BOOL) isValid;
 - (NSString *)validationMessage;

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -13,6 +13,7 @@
 #import "GTPageInterpreter.h"
 #import "GTInputFieldView.h"
 #import "GTLabel.h"
+#import "GTFileLoader.h"
 
 NSString const *emailRegEx =
 @"(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"
@@ -148,9 +149,9 @@ NSString const *emailRegEx =
 
 - (NSString *) validationMessage {
     if (![[self inputFieldValue] length]) {
-        return [NSString stringWithFormat:NSLocalizedString(@"GTInputFieldView_validationMessage_empty",nil), self.inputFieldLabel.text];
+        return [NSString stringWithFormat:[[GTFileLoader sharedInstance] localizedString:@"GTInputFieldView_validationMessage_empty"], self.inputFieldLabel.text];
     } else {
-        return [NSString stringWithFormat:NSLocalizedString(@"GTInputFieldView_validationMessage_badFormat", nil), self.inputFieldLabel.text];
+        return [NSString stringWithFormat:[[GTFileLoader sharedInstance] localizedString:@"GTInputFieldView_validationMessage_badFormat"], self.inputFieldLabel.text];
     }
 }
 @end

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -28,7 +28,7 @@ NSString const *emailRegEx =
 @property (strong, nonatomic, readwrite) NSString   *parameterName;
 @property (strong, nonatomic) UILabel               *inputFieldLabel;
 @property (strong, nonatomic) NSString              *inputFieldType;
-@property (strong, nonatomic) NSRegularExpression   *validationRegex;
+@property (strong, nonatomic) NSString              *validationRegex;
 
 @end
 
@@ -107,9 +107,7 @@ NSString const *emailRegEx =
     self.parameterName = [TBXML valueOfAttributeNamed:kAttr_name forElement:element];
 
     if ([TBXML valueOfAttributeNamed:kAttr_validFormat forElement:element]) {
-       self.validationRegex = [[NSRegularExpression alloc] initWithPattern:[TBXML valueOfAttributeNamed:kAttr_validFormat forElement:element]
-                                                                   options:NSRegularExpressionCaseInsensitive
-                                                                     error:nil];
+        self.validationRegex = [TBXML valueOfAttributeNamed:kAttr_validFormat forElement:element];
     }
     
     [self.inputTextField setFrame:CGRectMake(0, self.inputFieldLabel.frame.size.height, w, h)];
@@ -140,9 +138,7 @@ NSString const *emailRegEx =
         return true;
     }
     
-    return [self.validationRegex numberOfMatchesInString:[self inputFieldValue]
-                                                 options:0
-                                                   range:NSMakeRange(0, [[self inputFieldValue] length])];
+    return [[NSPredicate predicateWithFormat:@"SELF MATCHES %@", self.validationRegex] evaluateWithObject:self.inputFieldValue];
 }
 
 - (BOOL)isValidEmail {
@@ -152,9 +148,9 @@ NSString const *emailRegEx =
 
 - (NSString *) validationMessage {
     if (![[self inputFieldValue] length]) {
-        return [NSString stringWithFormat:@"%@ was empty.", self.inputFieldLabel.text];
+        return [NSString stringWithFormat:NSLocalizedString(@"GTInputFieldView_validationMessage_empty",nil), self.inputFieldLabel.text];
     } else {
-        return [NSString stringWithFormat:@"%@ was not properly formatted.", self.inputFieldLabel.text];
+        return [NSString stringWithFormat:NSLocalizedString(@"GTInputFieldView_validationMessage_badFormat", nil), self.inputFieldLabel.text];
     }
 }
 @end

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -98,10 +98,12 @@ NSString const *emailRegEx =
     
     if ([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:kInputFieldType_email]) {
         self.inputTextField.keyboardType = UIKeyboardTypeEmailAddress;
+        self.inputTextField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.inputTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
         self.inputFieldType = kInputFieldType_email;
     } else if([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:kInputFieldType_text]) {
         self.inputTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
+        self.inputTextField.autocorrectionType = UITextAutocorrectionTypeNo;
         self.inputFieldType = kInputFieldType_text;
     }
     
@@ -144,7 +146,7 @@ NSString const *emailRegEx =
 
 - (BOOL)isValidEmail {
     NSPredicate *regExPredicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", emailRegEx];
-    return [regExPredicate evaluateWithObject:self.inputFieldValue];
+    return [regExPredicate evaluateWithObject:[self.inputFieldValue lowercaseString]];
 }
 
 - (NSString *) validationMessage {

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -14,6 +14,15 @@
 #import "GTInputFieldView.h"
 #import "GTLabel.h"
 
+NSString const *emailRegEx =
+@"(?:[a-z0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[a-z0-9!#$%\\&'*+/=?\\^_`{|}"
+@"~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\"
+@"x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-"
+@"z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5"
+@"]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-"
+@"9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21"
+@"-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+
 @interface GTInputFieldView ()
 
 @property (strong, nonatomic) UILabel               *inputFieldLabel;
@@ -119,7 +128,11 @@
 }
 
 
-- (BOOL) isValid {
+- (BOOL)isValid {
+    if ([[self inputFieldType] isEqualToString:@"email"]) {
+        return [self isValidEmail];
+    }
+    
     if (!self.validationRegex) {
         return true;
     }
@@ -129,6 +142,10 @@
                                                    range:NSMakeRange(0, [[self inputFieldValue] length])];
 }
 
+- (BOOL)isValidEmail {
+    NSPredicate *regExPredicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", emailRegEx];
+    return [regExPredicate evaluateWithObject:self.inputFieldValue];
+}
 
 - (NSString *) validationMessage {
     if (![[self inputFieldValue] length]) {

--- a/GTViewController/Classes/Custom Classes/GTInputFieldView.m
+++ b/GTViewController/Classes/Custom Classes/GTInputFieldView.m
@@ -25,6 +25,7 @@ NSString const *emailRegEx =
 
 @interface GTInputFieldView ()
 
+@property (strong, nonatomic, readwrite) NSString   *parameterName;
 @property (strong, nonatomic) UILabel               *inputFieldLabel;
 @property (strong, nonatomic) NSString              *inputFieldType;
 @property (strong, nonatomic) NSRegularExpression   *validationRegex;
@@ -94,17 +95,19 @@ NSString const *emailRegEx =
         inputFieldChildElement = inputFieldChildElement->nextSibling;
     }
     
-    if ([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:@"email"]) {
+    if ([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:kInputFieldType_email]) {
         self.inputTextField.keyboardType = UIKeyboardTypeEmailAddress;
         self.inputTextField.autocapitalizationType = UITextAutocapitalizationTypeNone;
-        self.inputFieldType = @"email";
-    } else if([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:@"text"]) {
+        self.inputFieldType = kInputFieldType_email;
+    } else if([[TBXML valueOfAttributeNamed:kAttr_type forElement:element] isEqual:kInputFieldType_text]) {
         self.inputTextField.autocapitalizationType = UITextAutocapitalizationTypeWords;
-        self.inputFieldType = @"name";
+        self.inputFieldType = kInputFieldType_text;
     }
+    
+    self.parameterName = [TBXML valueOfAttributeNamed:kAttr_name forElement:element];
 
-    if ([TBXML valueOfAttributeNamed:@"valid-format" forElement:element]) {
-       self.validationRegex = [[NSRegularExpression alloc] initWithPattern:[TBXML valueOfAttributeNamed:@"valid-format" forElement:element]
+    if ([TBXML valueOfAttributeNamed:kAttr_validFormat forElement:element]) {
+       self.validationRegex = [[NSRegularExpression alloc] initWithPattern:[TBXML valueOfAttributeNamed:kAttr_validFormat forElement:element]
                                                                    options:NSRegularExpressionCaseInsensitive
                                                                      error:nil];
     }
@@ -129,7 +132,7 @@ NSString const *emailRegEx =
 
 
 - (BOOL)isValid {
-    if ([[self inputFieldType] isEqualToString:@"email"]) {
+    if ([[self inputFieldType] isEqualToString:kInputFieldType_email]) {
         return [self isValidEmail];
     }
     

--- a/GTViewController/Classes/Custom Classes/GTMultiButtonResponseView.h
+++ b/GTViewController/Classes/Custom Classes/GTMultiButtonResponseView.h
@@ -17,6 +17,6 @@
 @property (strong, nonatomic) UISnuffleButton *positiveButton;
 @property (strong, nonatomic) UISnuffleButton *negativeButton;
 
-- (instancetype) initWithFirstElement:(TBXMLElement *)firstElement secondElement:(TBXMLElement *)secondElement parentElement:(TBXMLElement *) parentElement yPosition:(CGFloat)y containerView:(UIView *)container withStyle:(GTPageStyle *) pageStyle;
+- (instancetype) initWithFirstElement:(TBXMLElement *)firstElement secondElement:(TBXMLElement *)secondElement parentElement:(TBXMLElement *) parentElement yPosition:(CGFloat)y containerView:(UIView *)container withStyle:(GTPageStyle *) pageStyle buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate ;
 
 @end

--- a/GTViewController/Classes/Custom Classes/GTMultiButtonResponseView.m
+++ b/GTViewController/Classes/Custom Classes/GTMultiButtonResponseView.m
@@ -15,7 +15,7 @@
 @implementation GTMultiButtonResponseView
 
 
-- (instancetype) initWithFirstElement:(TBXMLElement *)firstElement secondElement:(TBXMLElement *)secondElement parentElement:(TBXMLElement *) parentElement yPosition:(CGFloat)y containerView:(UIView *)container withStyle:(GTPageStyle *) pageStyle{
+- (instancetype) initWithFirstElement:(TBXMLElement *)firstElement secondElement:(TBXMLElement *)secondElement parentElement:(TBXMLElement *) parentElement yPosition:(CGFloat)y containerView:(UIView *)container withStyle:(GTPageStyle *) pageStyle buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate {
     TBXMLElement *positiveElement                  = nil;
     TBXMLElement *negativeElement                  = nil;
     
@@ -48,7 +48,7 @@
                                                                             yPos:0
                                                                        container:responseView
                                                                        withStyle:pageStyle
-                                                               buttonTapDelegate:nil];
+                                                               buttonTapDelegate:tapDelegate];
     
     
     
@@ -57,7 +57,7 @@
                                                                             yPos:0
                                                                        container:responseView
                                                                        withStyle:pageStyle
-                                                               buttonTapDelegate:nil];
+                                                               buttonTapDelegate:tapDelegate];
     
     [self layoutBasedOnAlignmentPositiveButton:positiveButton
                                 negativeButton:negativeButton

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.h
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.h
@@ -21,7 +21,7 @@ extern NSString * const UISnuffleButtonNotificationButtonTapEventKeyEventName;
 @property (nonatomic, strong) NSString			*mode;
 @property (nonatomic, strong) NSString			*urlTarget;
 @property (nonatomic, strong) NSArray			*tapEvents;
-@property (nonatomic, assign) BOOL              forceValidation;
+@property (nonatomic, assign) BOOL              validation;
 
 - (id)buttonWithElement:(TBXMLElement *)element addTag:(NSInteger)tag yPos:(CGFloat)yPos container:(UIView *)container withStyle:(GTPageStyle *)pageStyle buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)buttonDelegate;
 -(instancetype)initWithFrame:(CGRect)frame tapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate;

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.h
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.h
@@ -8,12 +8,12 @@
 
 #import <UIKit/UIKit.h>
 #import "TBXML.h"
-#import "GTPageStyle.h"
 
 extern NSString * const UISnuffleButtonNotificationButtonTapEvent;
 extern NSString * const UISnuffleButtonNotificationButtonTapEventKeyEventName;
 
 @protocol UISnuffleButtonTapDelegate;
+@class GTPageStyle;
 
 @interface UISnuffleButton : UIButton
 

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.h
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.h
@@ -40,5 +40,5 @@ extern NSString * const UISnuffleButtonNotificationButtonTapEventKeyEventName;
 - (void)didReceiveTapOnEmailButton:(UISnuffleButton *)emailButton;
 - (void)didReceiveTapOnAllURLButton:(UISnuffleButton *)allURLButton;
 - (void)didReceiveTapOnButton:(UISnuffleButton *)button;
-- (void)didReceiveTapOnPositiveButton:(UISnuffleButton *)positiveButton;
+- (BOOL)validateFields;
 @end

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.h
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.h
@@ -21,6 +21,7 @@ extern NSString * const UISnuffleButtonNotificationButtonTapEventKeyEventName;
 @property (nonatomic, strong) NSString			*mode;
 @property (nonatomic, strong) NSString			*urlTarget;
 @property (nonatomic, strong) NSArray			*tapEvents;
+@property (nonatomic, assign) BOOL              forceValidation;
 
 - (id)buttonWithElement:(TBXMLElement *)element addTag:(NSInteger)tag yPos:(CGFloat)yPos container:(UIView *)container withStyle:(GTPageStyle *)pageStyle buttonTapDelegate:(id<UISnuffleButtonTapDelegate>)buttonDelegate;
 -(instancetype)initWithFrame:(CGRect)frame tapDelegate:(id<UISnuffleButtonTapDelegate>)tapDelegate;
@@ -39,5 +40,5 @@ extern NSString * const UISnuffleButtonNotificationButtonTapEventKeyEventName;
 - (void)didReceiveTapOnEmailButton:(UISnuffleButton *)emailButton;
 - (void)didReceiveTapOnAllURLButton:(UISnuffleButton *)allURLButton;
 - (void)didReceiveTapOnButton:(UISnuffleButton *)button;
-
+- (void)didReceiveTapOnPositiveButton:(UISnuffleButton *)positiveButton;
 @end

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.m
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.m
@@ -456,9 +456,13 @@ extern NSString * const kButtonMode_allurl;
 				
 			}
 			
-            if (self.validation && self.tapDelegate && [self.tapDelegate respondsToSelector:@selector(didReceiveTapOnPositiveButton:)]) {
-                [self.tapDelegate didReceiveTapOnPositiveButton:self];
-            } else {
+            BOOL fieldsAreValid = YES;
+            
+            if (self.validation && self.tapDelegate && [self.tapDelegate respondsToSelector:@selector(validateFields)]) {
+                fieldsAreValid = [self.tapDelegate validateFields];
+            }
+            
+            if (fieldsAreValid) {
                 [self.tapEvents enumerateObjectsUsingBlock:^(NSString *eventName, NSUInteger idx, BOOL *stop) {
                     if (eventName) {
                         NSString *trimmedEventName = [eventName stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];

--- a/GTViewController/Classes/Custom Classes/UISnuffleButton.m
+++ b/GTViewController/Classes/Custom Classes/UISnuffleButton.m
@@ -87,7 +87,7 @@ extern NSString * const kButtonMode_allurl;
         NSString							*textSizeString		= nil;
         NSString							*y					= nil;
         NSString							*image				= nil;
-        NSString                            *forceValidationString    = nil;
+        NSString                            *validationString   = nil;
         NSArray								*tapEvents			= nil;
         CGFloat                             h                   = 0;
         CGFloat                             w                   = 0;
@@ -117,7 +117,7 @@ extern NSString * const kButtonMode_allurl;
             y					= [TBXML valueOfAttributeNamed:kAttr_y		forElement:element];
             h					= round([[TBXML valueOfAttributeNamed:kAttr_height	forElement:element] floatValue]);
             w					= round([[TBXML valueOfAttributeNamed:kAttr_width  forElement:element] floatValue]);
-            forceValidationString     = [TBXML valueOfAttributeNamed:kAttr_forceValidation forElement:element];
+            validationString    = [TBXML valueOfAttributeNamed:kAttr_validation forElement:element];
         } else {
             text				= [TBXML textForElement:button_label];
             textColorString		= [TBXML valueOfAttributeNamed:kAttr_color	forElement:button_label];
@@ -153,7 +153,7 @@ extern NSString * const kButtonMode_allurl;
         UIControlContentVerticalAlignment	contentVerticalAlignment;
         UIEdgeInsets						edgeInset			= UIEdgeInsetsZero;
         BOOL								hide				= YES;
-        BOOL                                forceValidation     = NO;
+        BOOL                                validation          = NO;
         
         //set defaults based on mode
         if ([mode isEqual:kButtonMode_big]) {
@@ -231,10 +231,12 @@ extern NSString * const kButtonMode_allurl;
             contentHorizontalAlignment	= UIControlContentHorizontalAlignmentCenter;
             contentVerticalAlignment	= UIControlContentVerticalAlignmentCenter;
             
-            forceValidation             = [[TBXML elementName:element] isEqual:kName_Positive_Button] &&
-                                            forceValidationString &&
-                                            ([[forceValidationString lowercaseString] isEqualToString:@"yes"] ||
-                                             [[forceValidationString lowercaseString] isEqualToString:@"true"]);
+            // gate on positive-buttons first.
+            if ([[TBXML elementName:element] isEqual:kName_Positive_Button]) {
+                validation = !validationString ||
+                    (![[validationString lowercaseString] isEqualToString:@"no"] && ![[validationString lowercaseString] isEqualToString:@"false"]);
+                
+            }
         } else {
             frame						= CGRectMake(BUTTONXOFFSET,
                                                      yPos + 2,
@@ -298,7 +300,7 @@ extern NSString * const kButtonMode_allurl;
         [buttonTemp setContentEdgeInsets:edgeInset];
         [buttonTemp setTag:tag];
         [buttonTemp setHidden:hide];
-        [buttonTemp setForceValidation:forceValidation];
+        [buttonTemp setValidation:validation];
         
         return buttonTemp;
         
@@ -454,7 +456,7 @@ extern NSString * const kButtonMode_allurl;
 				
 			}
 			
-            if (self.forceValidation && self.tapDelegate && [self.tapDelegate respondsToSelector:@selector(didReceiveTapOnPositiveButton:)]) {
+            if (self.validation && self.tapDelegate && [self.tapDelegate respondsToSelector:@selector(didReceiveTapOnPositiveButton:)]) {
                 [self.tapDelegate didReceiveTapOnPositiveButton:self];
             } else {
                 [self.tapEvents enumerateObjectsUsingBlock:^(NSString *eventName, NSUInteger idx, BOOL *stop) {

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import "UISnuffleButton.h"
+
 extern NSString *const GTFollowupViewControllerFieldSubscriptionNotificationName;
 extern NSString *const GTFollowupViewControllerFieldSubscriptionEventName;
 extern NSString *const GTFollowupViewControllerFieldKeyEmail;
@@ -16,12 +18,13 @@ extern NSString *const GTFollowupViewControllerFieldKeyFollowupId;
 
 @class GTFollowupModalView, GTFollowupThankYouView;
 
-@interface GTFollowupViewController : UIViewController<UITextFieldDelegate, UIAlertViewDelegate>
+@interface GTFollowupViewController : UIViewController<UITextFieldDelegate, UIAlertViewDelegate, UISnuffleButtonTapDelegate>
 
 @property (strong,nonatomic) GTFollowupModalView *followupModalView;
 @property (strong,nonatomic) GTFollowupThankYouView *followupThankYouView;
 
-- (id)initWithFollowupView:(GTFollowupModalView *)followupModalView;
-- (id)initWithFollowupView:(GTFollowupModalView *)followupModalView thankYouView:(GTFollowupThankYouView *)thankYouView;
+- (void)setFollowupView:(GTFollowupModalView *)followupModalView;
+- (void)setFollowupView:(GTFollowupModalView *)followupModalView andThankYouView:(GTFollowupThankYouView *)thankYouView;
+
 - (void)transitionToThankYou;
 @end

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.h
@@ -16,7 +16,7 @@ extern NSString *const GTFollowupViewControllerFieldKeyFollowupId;
 
 @class GTFollowupModalView, GTFollowupThankYouView;
 
-@interface GTFollowupViewController : UIViewController<UITextFieldDelegate>
+@interface GTFollowupViewController : UIViewController<UITextFieldDelegate, UIAlertViewDelegate>
 
 @property (strong,nonatomic) GTFollowupModalView *followupModalView;
 @property (strong,nonatomic) GTFollowupThankYouView *followupThankYouView;

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -10,6 +10,7 @@
 
 #import "GTFollowUpViewController.h"
 
+#import "GTFileLoader.h"
 #import "GTInputFieldView.h"
 #import "GTFollowupModalView.h"
 #import "GTFollowupThankYouView.h"
@@ -275,9 +276,9 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 - (void)didReceiveTapOnPositiveButton:(UISnuffleButton *)positiveButton {    
     NSArray *inputValidationErrors = [self inputValidationErrors];
-    
+
     if ([positiveButton validation] && [inputValidationErrors count]) {
-        [[[UIAlertView alloc] initWithTitle:NSLocalizedString(@"GTFollowupViewController_validation_title",nil)
+        [[[UIAlertView alloc] initWithTitle:[[GTFileLoader sharedInstance] localizedString:@"GTFollowupViewController_validation_title"]
                                     message:[inputValidationErrors componentsJoinedByString:@"\n"]
                                    delegate:self
                           cancelButtonTitle:@"Ok"

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -277,7 +277,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     NSArray *inputValidationErrors = [self inputValidationErrors];
     
     if ([positiveButton validation] && [inputValidationErrors count]) {
-        [[[UIAlertView alloc] initWithTitle:@"Please correct these fields:"
+        [[[UIAlertView alloc] initWithTitle:NSLocalizedString(@"GTFollowupViewController_validation_title",nil)
                                     message:[inputValidationErrors componentsJoinedByString:@"\n"]
                                    delegate:self
                           cancelButtonTitle:@"Ok"

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -27,7 +27,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 
 @property (weak, nonatomic)         UITextField *activeField;
 @property (assign, nonatomic)       CGFloat originalHeight;
-
+@property (assign, nonatomic)       CGRect visibleFrame;
 @end
 
 @implementation GTFollowupViewController
@@ -187,6 +187,8 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     // if just the frame is considered, then the label could show while the input is hidden
     unobscuredByKeyboardFrame.size.height -= CGRectGetHeight(inputFieldViewFrame);
     
+    self.visibleFrame = unobscuredByKeyboardFrame;
+    
     if (CGRectContainsPoint(unobscuredByKeyboardFrame, inputFieldViewFrame.origin) ) {
         return;
     }
@@ -194,6 +196,11 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     CGFloat viewVerticalDelta = (CGRectGetMinY(inputFieldViewFrame) + CGRectGetHeight(inputFieldViewFrame)) - CGRectGetHeight(unobscuredByKeyboardFrame);
     UIViewAnimationCurve animationCurve;
     NSTimeInterval animationDuration;
+    
+    self.visibleFrame = CGRectMake(CGRectGetMinX(self.visibleFrame),
+                                   CGRectGetMinY(self.visibleFrame),
+                                   CGRectGetWidth(self.visibleFrame),
+                                   CGRectGetHeight(self.visibleFrame) + viewVerticalDelta);
     
     [[userInfo objectForKey:UIKeyboardAnimationCurveUserInfoKey] getValue:&animationCurve];
     [[userInfo objectForKey:UIKeyboardAnimationDurationUserInfoKey] getValue:&animationDuration];
@@ -245,8 +252,13 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 }
 
 - (CGFloat)calculateVerticalDeltaFromCurrentField:(UIView *)currentField toNextField:(UIView *)nextField {
-    return CGRectGetMinY(nextField.frame) - CGRectGetMinY(currentField.frame);
+    CGRect nextFrame = nextField.frame;
     
+    if (CGRectContainsPoint(self.visibleFrame, nextField.frame.origin)) {
+        return 0;
+    }
+    
+    return CGRectGetMinY(nextField.frame) - CGRectGetMinY(currentField.frame);
 }
 
 #pragma mark - UITextFieldDelegate methods
@@ -276,6 +288,11 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
                                                                  toNextField:nextActiveField.superview];
         
         self.activeField = nextActiveField;
+    
+        self.visibleFrame = CGRectMake(CGRectGetMinX(self.visibleFrame),
+                                       CGRectGetMinY(self.visibleFrame),
+                                       CGRectGetWidth(self.visibleFrame),
+                                       CGRectGetHeight(self.visibleFrame) + verticalDelta);
         
         [self animateViewWithVerticalDelta:verticalDelta animationDuration:0.3 animationCurve:UIViewAnimationCurveEaseOut];
         

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -120,6 +120,17 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
         return;
     }
     
+    NSArray *inputValidationErrors = [self inputValidationErrors];
+    
+    if ([inputValidationErrors count]) {
+        [[[UIAlertView alloc] initWithTitle:@"Please correct these fields:"
+                                    message:[inputValidationErrors componentsJoinedByString:@"\n"]
+                                   delegate:self
+                          cancelButtonTitle:@"Ok"
+                          otherButtonTitles:nil] show];
+        return;
+    }
+    
     __block NSMutableDictionary *followupDetailsDictionary = [[NSMutableDictionary alloc]init];
     [followupDetailsDictionary setValue:self.followupModalView.followupId forKey:GTFollowupViewControllerFieldKeyFollowupId];
     
@@ -139,7 +150,26 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 }
 
 
+- (NSArray *)inputValidationErrors {
+    __block NSMutableArray *validationErrors = @[].mutableCopy;
+
+    [self.followupModalView.inputFieldViews enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        GTInputFieldView *inputFieldView = obj;
+        
+        if (![inputFieldView isValid]) {
+            [validationErrors addObject:[inputFieldView validationMessage]];
+        }
+    }];
+    
+    return validationErrors;
+}
+
+
 - (void)transitionToThankYou {
+    if ([self inputValidationErrors]) {
+        return;
+    }
+
     [self.view addSubview:self.followupThankYouView];
     
     [UIView animateWithDuration:2.0 animations:^{

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -105,6 +105,12 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 - (void)transitionToThankYou {
     [self.view addSubview:self.followupThankYouView];
     
+    [self.followupModalView.inputFieldViews enumerateObjectsUsingBlock:^(GTInputFieldView *inputFieldView, NSUInteger idx, BOOL * _Nonnull stop) {
+        if([inputFieldView.inputTextField isFirstResponder]) {
+            [inputFieldView.inputTextField resignFirstResponder];
+        }
+    }];
+    
     [UIView animateWithDuration:2.0 animations:^{
         [self.view bringSubviewToFront:self.followupThankYouView];
     }];

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -276,7 +276,7 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
 - (void)didReceiveTapOnPositiveButton:(UISnuffleButton *)positiveButton {    
     NSArray *inputValidationErrors = [self inputValidationErrors];
     
-    if ([positiveButton forceValidation] && [inputValidationErrors count]) {
+    if ([positiveButton validation] && [inputValidationErrors count]) {
         [[[UIAlertView alloc] initWithTitle:@"Please correct these fields:"
                                     message:[inputValidationErrors componentsJoinedByString:@"\n"]
                                    delegate:self

--- a/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTFollowupViewController.m
@@ -14,6 +14,8 @@
 #import "GTFollowupModalView.h"
 #import "GTFollowupThankYouView.h"
 
+NSString *const GTFollowupViewControllerParameterName_Name                      = @"name";
+NSString *const GTFollowupViewControllerParameterName_Email                     = @"email";
 NSString *const GTFollowupViewControllerFieldSubscriptionNotificationName       = @"org.cru.godtools.GTFollowupModalView.followupSubscriptionNotificationName";
 NSString *const GTFollowupViewControllerFieldSubscriptionEventName              = @"followup:subscribe";
 NSString *const GTFollowupViewControllerFieldKeyEmail                           = @"org.cru.godtools.GTFollowupModalView.fieldKeyEmail";
@@ -107,9 +109,9 @@ NSString *const GTFollowupViewControllerFieldKeyFollowupId                      
     [self.followupModalView.inputFieldViews enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         GTInputFieldView *inputFieldView = obj;
         
-        if ([[inputFieldView inputFieldType] isEqualToString:@"name"] && inputFieldView.inputFieldValue) {
+        if ([inputFieldView.parameterName isEqualToString:GTFollowupViewControllerParameterName_Name] && inputFieldView.inputFieldValue) {
             [followupDetailsDictionary setValue:inputFieldView.inputFieldValue forKey:GTFollowupViewControllerFieldKeyName];
-        } else if ([[inputFieldView inputFieldType] isEqualToString:@"email"]) {
+        } else if ([inputFieldView.parameterName isEqualToString:GTFollowupViewControllerParameterName_Email] && inputFieldView.inputFieldValue) {
             [followupDetailsDictionary setValue:inputFieldView.inputFieldValue forKey:GTFollowupViewControllerFieldKeyEmail];
         }
     }];

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
@@ -105,7 +105,7 @@ extern NSString * const kAttr_height;
 extern NSString * const kAttr_tap_events;
 extern NSString * const kAttr_followup_id;
 extern NSString * const kAttr_context_id;
-extern NSString * const kAttr_forceValidation;
+extern NSString * const kAttr_validation;
 extern NSString * const kAttr_validFormat;
 extern NSString * const kAttr_name;
 extern NSString * const kAttr_listeners;

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
@@ -106,6 +106,8 @@ extern NSString * const kAttr_tap_events;
 extern NSString * const kAttr_followup_id;
 extern NSString * const kAttr_context_id;
 extern NSString * const kAttr_forceValidation;
+extern NSString * const kAttr_validFormat;
+extern NSString * const kAttr_name;
 extern NSString * const kAttr_listeners;
 extern NSString * const kAttr_type;
 
@@ -144,6 +146,10 @@ extern NSString * const kLabelModifer_normal;
 extern NSString * const kLabelModifer_bold;
 extern NSString * const kLabelModifer_italics;
 extern NSString * const kLabelModifer_bolditalics;
+
+//input field type constants
+extern NSString * const kInputFieldType_email;
+extern NSString * const kInputFieldType_text;
 
 @interface GTPageInterpreter : GTInterpreter
 

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.h
@@ -105,6 +105,7 @@ extern NSString * const kAttr_height;
 extern NSString * const kAttr_tap_events;
 extern NSString * const kAttr_followup_id;
 extern NSString * const kAttr_context_id;
+extern NSString * const kAttr_forceValidation;
 extern NSString * const kAttr_listeners;
 extern NSString * const kAttr_type;
 

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
@@ -76,7 +76,7 @@ NSString * const kAttr_followup_id      = @"followup-id";
 NSString * const kAttr_context_id       = @"context-id";
 extern NSString * const kAttr_listeners;
 NSString * const kAttr_type             = @"type";
-NSString * const kAttr_forceValidation  = @"force-validation";
+NSString * const kAttr_validation       = @"validation";
 NSString * const kAttr_validFormat      = @"valid-format";
 NSString * const kAttr_name             = @"name";
 

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
@@ -76,6 +76,7 @@ NSString * const kAttr_followup_id      = @"followup-id";
 NSString * const kAttr_context_id       = @"context-id";
 extern NSString * const kAttr_listeners;
 NSString * const kAttr_type             = @"type";
+NSString * const kAttr_forceValidation  = @"force-validation";
 
 NSString * const kAttr_yoff				= @"yoffset";
 NSString * const kAttr_xoff				= @"xoffset";
@@ -829,12 +830,15 @@ NSString * const kLabelModifer_bolditalics	= @"bold-italics";
             
             ////FOLLOWUP MODAL
             if ( [elementName isEqual:kName_Followup_Modal]) {
+                GTFollowupViewController *viewController = [[GTFollowupViewController alloc]init];
+                
                 GTFollowupModalView *followupModalView = [[GTFollowupModalView alloc] initFromElement:object_el
                                                                                             withStyle:self.pageStyle
                                                                                        presentingView:self.pageView
-                                                                                  interpreterDelegate:self.delegate];
+                                                                                  interpreterDelegate:self.delegate
+                                                                                    buttonTapDelegate:viewController];
                 
-                GTFollowupViewController *viewController = [[GTFollowupViewController alloc]initWithFollowupView:followupModalView];
+                [viewController setFollowupView:followupModalView];
                 
                 NSArray *listeners = [[TBXML valueOfAttributeNamed:kAttr_listeners forElement:object_el] componentsSeparatedByString:@","];
                 
@@ -1265,7 +1269,8 @@ NSString * const kLabelModifer_bolditalics	= @"bold-italics";
                                                                                    parentElement:object_el
                                                                                        yPosition:object_ypos
                                                                                    containerView:tempContainerView
-                                                                                       withStyle:self.pageStyle];
+                                                                                       withStyle:self.pageStyle
+                                                                               buttonTapDelegate:nil];
                 
                 maxWidth			= fmaxf(maxWidth, CGRectGetMaxX(multiButtonResponseView.frame));
                 maxHeight			= fmaxf(maxHeight, CGRectGetMaxY(multiButtonResponseView.frame));

--- a/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
+++ b/GTViewController/Classes/Parsing Classes/GTPageInterpreter.m
@@ -77,6 +77,8 @@ NSString * const kAttr_context_id       = @"context-id";
 extern NSString * const kAttr_listeners;
 NSString * const kAttr_type             = @"type";
 NSString * const kAttr_forceValidation  = @"force-validation";
+NSString * const kAttr_validFormat      = @"valid-format";
+NSString * const kAttr_name             = @"name";
 
 NSString * const kAttr_yoff				= @"yoffset";
 NSString * const kAttr_xoff				= @"xoffset";
@@ -114,6 +116,8 @@ NSString * const kLabelModifer_bold		= @"bold";
 NSString * const kLabelModifer_italics	= @"italics";
 NSString * const kLabelModifer_bolditalics	= @"bold-italics";
 
+NSString * const kInputFieldType_email  = @"email";
+NSString * const kInputFieldType_text   = @"text";
 
 @interface GTPageInterpreter ()
 

--- a/GTViewController/Resources/en.lproj/GTViewController.strings
+++ b/GTViewController/Resources/en.lproj/GTViewController.strings
@@ -7,7 +7,7 @@
 */
 
 "GTInputFieldView_validationMessage_empty"           = "%@ was empty";
-"GTInputFieldView_validationMessage_badFormat"       = "%%@ was not properly formatted";
+"GTInputFieldView_validationMessage_badFormat"       = "%@ was not properly formatted";
 
 "GTFollowupViewController_validation_title"          = "Please correct these fields:";
 

--- a/GTViewController/Resources/en.lproj/GTViewController.strings
+++ b/GTViewController/Resources/en.lproj/GTViewController.strings
@@ -6,6 +6,11 @@
   Copyright (c) 2015 Michael Harrison. All rights reserved.
 */
 
+"GTInputFieldView_validationMessage_empty"           = "%@ was empty";
+"GTInputFieldView_validationMessage_badFormat"       = "%%@ was not properly formatted";
+
+"GTFollowupViewController_validation_title"          = "Please correct these fields:";
+
 "GTViewController_urlButton_cancel"                  = "Cancel";
 "GTViewController_urlButton_copy"                    = "Copy";
 "GTViewController_urlButton_email"                   = "Email";


### PR DESCRIPTION
 - add a UISnuffleButtonTapDelegate method to handle validation on a positive button
 - when true, all input fields will be validated
 - if validation passes, then listeners on that button are fired
    - followup:subscribed is not posted to notification center, instead handled w/in the class
 - email addresses are validated automatically
 - otherwise a regex can be provided