### PR TITLE
Prevent view controller from being presented twice

### DIFF
--- a/GTViewController.podspec
+++ b/GTViewController.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "GTViewController"
-  s.version      = "7.0.0"
+  s.version      = "7.0.1"
   s.summary      = "A View Controller that renders God Tools xml packages"
   s.description  = <<-DESC
                    GTViewController takes a God Tools xml package and renders it for iOS devices.

--- a/GTViewController/Classes/Nav Classes/GTViewController.m
+++ b/GTViewController/Classes/Nav Classes/GTViewController.m
@@ -1177,6 +1177,11 @@ NSString * const kAttr_listeners	= @"listeners";
     self.activeViewMasked = NO;
     [self.followupViewController setPackageCode:self.packageCode andLanguageCode:self.languageCode];
     
+    if ([self.followupViewController isBeingPresented]) {
+        NSLog(@"%@", @"followupViewController is already being presented.  not presenting it again.");
+        return;
+    }
+    
     [self presentViewController:self.followupViewController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
- not sure what's causing it, unless for some reason two events are being emitted in some case
- double touching really really quickly will not reproduce the issue

Addresses: https://fabric.io/cru/ios/apps/org.cru.godtools/issues/57113121ffcdc04250bfb993
